### PR TITLE
v1.2.0

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,4 +57,4 @@ jobs:
       run: |
         (cd tests/utils && nohup python -m flask run --port 3000 &)
         wait-for-it localhost:3000
-        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.10.2 --exclude=details --ci
+        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.11.0 --ci

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python3 -m build
         twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/1.1.0...main)
+## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/1.2.0...main)
+
+## [1.2.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/1.2.0) - 09/02/2021
+
+### Added
+
+- [Cookie banner](https://design-system.service.gov.uk/components/cookie-banner/) component
 
 ### Changed
 
 - Update to [GOV.UK Frontend v3.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.11.0)
+- Empty data URI in PNG version of the header logo
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/1.1.0...main)
 
+### Changed
+
+- Update to [GOV.UK Frontend v3.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.11.0)
+
 ### Fixed
 
 - Missing install dependency on Jinja2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/1.1.0...main)
 
+### Fixed
+
+- Missing install dependency on Jinja2
+
 ## [1.1.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/1.1.0) - 18/12/2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GOV.UK Frontend Jinja Macros
 
 [![PyPI version](https://badge.fury.io/py/govuk-frontend-jinja.svg)](https://pypi.org/project/govuk-frontend-jinja/)
-![govuk-frontend 3.10.2](https://img.shields.io/badge/govuk--frontend%20version-3.10.2-005EA5?logo=gov.uk&style=flat)
+![govuk-frontend 3.11.0](https://img.shields.io/badge/govuk--frontend%20version-3.11.0-005EA5?logo=gov.uk&style=flat)
 ![Build](https://github.com/LandRegistry/govuk-frontend-jinja/workflows/Build/badge.svg)
 
 This repository provides a complete set of [Jinja](https://jinja.palletsprojects.com/) macro ports that are kept up-to-date and 100% compliant with the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) Nunjucks macros. Porting is intentionally manual rather than automated to make updates simpler than maintaining an automated conversion routine. A [comprehensive test suite](https://github.com/surevine/govuk-frontend-diff) ensures compliance against the latest, and every subsequent, GOV.UK Frontend release.
@@ -41,7 +41,7 @@ There is a test server at `tests/utils/app.py` which you will need to run using 
 You can then run the tests using `govuk-frontend-diff` as follows:
 
 ```bash
-./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.10.2
+./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.11.0
 ```
 
 This is all wrapped up in `./test.sh` for simplified running (Requires Docker).

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 rm -rf build
 rm -rf dist
 rm -rf govuk_frontend_jinja.egg-info
-python3 setup.py sdist bdist_wheel
+python3 -m build

--- a/govuk_frontend_jinja/templates/components/cookie-banner/macro.html
+++ b/govuk_frontend_jinja/templates/components/cookie-banner/macro.html
@@ -1,2 +1,65 @@
 {% macro govukCookieBanner (params) %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
+<div class="govuk-cookie-banner {{ params.classes if params.classes }}" role="region" aria-label="{{ params.ariaLabel | default('Cookie banner') }}"
+  {%- if params.hidden %} hidden{% endif %}
+  {%- for attribute, value in (params.attributes.items() if params.attributes else {}.items()) %} {{attribute}}="{{value}}"{% endfor %}>
+
+  {%- for message in params.messages %}
+    {% set classNames = "govuk-cookie-banner__message govuk-width-container" %}
+    {% if message.classes %}
+      {% set classNames = classNames + " " + message.classes %}
+    {% endif %}
+
+    <div class="{{classNames}}" {%- if message.role %} role="{{message.role}}"{% endif %}
+    {%- for attribute, value in (message.attributes.items() if message.attributes else {}.items()) %} {{attribute}}="{{value}}"{% endfor %}
+    {% if message.hidden %} hidden{% endif %}>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if message.headingHtml or message.headingText %}
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          {%- if message.headingHtml -%}
+            {{ message.headingHtml | safe }}
+          {%- else -%}
+            {{ message.headingText }}
+          {%- endif -%}
+        </h2>
+        {% endif %}
+
+        <div class="govuk-cookie-banner__content">
+          {%- if message.html -%}
+            {{ message.html | safe }}
+          {%- elif message.text -%}
+            <p class="govuk-body">{{ message.text }}</p>
+          {%- endif -%}
+        </div>
+      </div>
+    </div>
+
+      {% if message.actions %}
+      <div class="govuk-button-group">
+        {% for action in message.actions %}
+          {% if action.href %}
+            {% set linkClasses = "govuk-link" %}
+            {% if action.classes %}
+              {% set linkClasses = linkClasses + " " + action.classes %}
+            {% endif %}
+            <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in (action.attributes.items() if action.attributes else {}.items()) %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
+          {% else %}
+            {{ govukButton({
+              'text': action.text,
+              'value': action.value,
+              'name': action.name,
+              'type': action.type,
+              'classes': action.classes,
+              'attributes': action.attributes
+            }) | indent(12) | trim }}
+          {% endif %}
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+  {% endfor %}
+</div>
 {% endmacro %}

--- a/govuk_frontend_jinja/templates/components/cookie-banner/macro.html
+++ b/govuk_frontend_jinja/templates/components/cookie-banner/macro.html
@@ -1,0 +1,2 @@
+{% macro govukCookieBanner (params) %}
+{% endmacro %}

--- a/govuk_frontend_jinja/templates/components/header/macro.html
+++ b/govuk_frontend_jinja/templates/components/header/macro.html
@@ -9,9 +9,11 @@
           currentColor into the crown whilst continuing to support older browsers
           which do not support external SVGs without a Javascript polyfill. This
           adds approximately 1kb to every page load.
+
           We use currentColour so that we can easily invert it when printing and
           when the focus state is applied. This also benefits users who override
           colours in their browser as they will still see the crown.
+
           The SVG needs `focusable="false"` so that Internet Explorer does not
           treat it as an interactive element - without this it will be
           'focusable' when using the keyboard to navigate. #}
@@ -29,14 +31,16 @@
               d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
             ></path>
             {#- Fallback PNG image for older browsers.
+
             The <image> element is a valid SVG element. In SVG, you would specify
             the URL of the image file with the xlink:href – as we don't reference an
-            image it has no effect. It's important to include the empty xlink:href
-            attribute as this prevents versions of IE which support SVG from
-            downloading the fallback image when they don't need to.
+            image it has no effect. It's important to include an empty data URI
+            as the xlink:href attribute as this prevents versions of IE which
+            support SVG from downloading the fallback image when they don't need to.
+
             In other browsers <image> is synonymous for the <img> tag and will be
             interpreted as such, displaying the fallback image. #}
-            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="data:," display="none" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
           </svg>
           <span class="govuk-header__logotype-text">
             GOV.UK
@@ -80,5 +84,4 @@
     {% endif %}
   </div>
 </header>
-
 {% endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for directory in directories:
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="1.1.0",
+    version="1.1.1",
     author="Matt Shaw",
     author_email="matthew.shaw@landregistry.gov.uk",
     description="GOV.UK Frontend Jinja Macros",
@@ -34,4 +34,5 @@ setuptools.setup(
         "Topic :: Text Processing :: Markup :: HTML",
     ],
     python_requires=">=3.6",
+    install_requires=["jinja2"],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for directory in directories:
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="1.1.1",
+    version="1.2.0",
     author="Matt Shaw",
     author_email="matthew.shaw@landregistry.gov.uk",
     description="GOV.UK Frontend Jinja Macros",

--- a/tests/utils/test-entrypoint.sh
+++ b/tests/utils/test-entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 flake8 .
 (cd tests/utils && nohup python -m flask run --port 3000 &)
 wait-for-it localhost:3000
-./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.10.2 --exclude=details
+./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v3.11.0


### PR DESCRIPTION
### Added

- [Cookie banner](https://design-system.service.gov.uk/components/cookie-banner/) component

### Changed

- Update to [GOV.UK Frontend v3.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.11.0)
- Empty data URI in PNG version of the header logo

### Fixed

- Missing install dependency on Jinja2