### PR TITLE
Added pre element to example HTML in details macro

### DIFF
--- a/govuk_frontend_jinja/templates/components/details/macro.html
+++ b/govuk_frontend_jinja/templates/components/details/macro.html
@@ -6,7 +6,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    {{ params.html | safe if params.html else params.text }}
+    <pre><code>{{ params.html | safe if params.html else params.text }}</code></pre>
   </div>
 </details>
 


### PR DESCRIPTION
Properly formats the HTML to the user in a `<pre><code>...</code></pre>` block