### PR TITLE
GOV.UK Frontend 4.7.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,5 +46,5 @@ jobs:
       run: |
         (cd tests/utils && nohup python -m flask run --port 3000 &)
         wait-for-it localhost:3000
-        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v4.6.0 --ci
+        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v4.7.0 --ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [GOV.UK Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) support
+- [Exit this page component](https://design-system.service.gov.uk/components/exit-this-page/)
 
 ## [2.6.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.6.0) - 25/04/2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/2.6.0...main)
+## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/2.7.0...main)
+
+## [2.7.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.7.0) - xx/07/2023
+
+### Added
+
+- [GOV.UK Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) support
 
 ## [2.6.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.6.0) - 25/04/2023
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following table shows the version of GOV.UK Frontend Jinja that you should u
 
 | GOV.UK Frontend Jinja Version | Target GOV.UK Frontend Version |
 | ----------------------------- | ------------------------------ |
+| [2.7.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.7.0) | [4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) |
 | [2.6.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.6.0) | [4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0) |
 | [2.5.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.5.0) | [4.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.5.0) |
 | [2.4.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/2.4.0) | [4.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.1) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GOV.UK Frontend Jinja Macros
 
 [![PyPI version](https://badge.fury.io/py/govuk-frontend-jinja.svg)](https://pypi.org/project/govuk-frontend-jinja/)
-![govuk-frontend 4.6.0](https://img.shields.io/badge/govuk--frontend%20version-4.6.0-005EA5?logo=gov.uk&style=flat)
+![govuk-frontend 4.7.0](https://img.shields.io/badge/govuk--frontend%20version-4.7.0-005EA5?logo=gov.uk&style=flat)
 [![Python package](https://github.com/LandRegistry/govuk-frontend-jinja/actions/workflows/python-package.yml/badge.svg)](https://github.com/LandRegistry/govuk-frontend-jinja/actions/workflows/python-package.yml)
 
 **GOV.UK Frontend Jinja is a [community tool](https://design-system.service.gov.uk/community/resources-and-tools/) of the [GOV.UK Design System](https://design-system.service.gov.uk/). The Design System team is not responsible for it and cannot support you with using it. Contact the [maintainers](#contributors) directly if you need [help](#support) or you want to request a feature.**

--- a/govuk_frontend_jinja/templates/components/exit-this-page/macro.html
+++ b/govuk_frontend_jinja/templates/components/exit-this-page/macro.html
@@ -1,0 +1,18 @@
+{% macro govukExitThisPage(params) %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+
+<div
+    {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-exit-this-page" {%- for attribute, value in (params.attributes.items() if params.attributes else {}.items()) %} {{attribute}}="{{value | lower}}"{% endfor %}
+    {%- if params.activatedText %} data-i18n.activated="{{ params.activatedText | escape }}"{% endif %}
+    {%- if params.timedOutText %} data-i18n.timed-out="{{ params.timedOutText | escape }}"{% endif %}
+    {%- if params.pressTwoMoreTimesText %} data-i18n.press-two-more-times="{{ params.pressTwoMoreTimesText | escape }}"{% endif %}
+    {%- if params.pressOneMoreTimeText %} data-i18n.press-one-more-time="{{ params.pressOneMoreTimeText | escape }}"{% endif %}
+>
+    {{- govukButton({
+        'html': params.html,
+        'text': params.text | default("Exit this page"),
+        'classes': "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
+        'href': params.redirectUrl | default("https://www.bbc.co.uk/weather")
+    }) -}}
+</div>
+{% endmacro %}

--- a/requirements-test-3.10.txt
+++ b/requirements-test-3.10.txt
@@ -4,17 +4,19 @@
 #
 #    pip-compile --output-file=requirements-test-3.10.txt requirements-test.in
 #
-click==8.1.3
+blinker==1.6.2
+    # via flask
+click==8.1.4
     # via flask
 flake8==6.0.0
     # via -r requirements-test.in
-flask==2.2.3
+flask==2.3.2
     # via -r requirements-test.in
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -24,5 +26,5 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-werkzeug==2.2.3
+werkzeug==2.3.6
     # via flask

--- a/requirements-test-3.11.txt
+++ b/requirements-test-3.11.txt
@@ -4,17 +4,19 @@
 #
 #    pip-compile --output-file=requirements-test-3.11.txt requirements-test.in
 #
-click==8.1.3
+blinker==1.6.2
+    # via flask
+click==8.1.4
     # via flask
 flake8==6.0.0
     # via -r requirements-test.in
-flask==2.2.3
+flask==2.3.2
     # via -r requirements-test.in
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -24,5 +26,5 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-werkzeug==2.2.3
+werkzeug==2.3.6
     # via flask

--- a/requirements-test-3.8.txt
+++ b/requirements-test-3.8.txt
@@ -4,19 +4,21 @@
 #
 #    pip-compile --output-file=requirements-test-3.8.txt requirements-test.in
 #
-click==8.1.3
+blinker==1.6.2
+    # via flask
+click==8.1.4
     # via flask
 flake8==6.0.0
     # via -r requirements-test.in
-flask==2.2.3
+flask==2.3.2
     # via -r requirements-test.in
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via flask
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -26,7 +28,7 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-werkzeug==2.2.3
+werkzeug==2.3.6
     # via flask
-zipp==3.15.0
+zipp==3.16.0
     # via importlib-metadata

--- a/requirements-test-3.9.txt
+++ b/requirements-test-3.9.txt
@@ -4,19 +4,21 @@
 #
 #    pip-compile --output-file=requirements-test-3.9.txt requirements-test.in
 #
-click==8.1.3
+blinker==1.6.2
+    # via flask
+click==8.1.4
     # via flask
 flake8==6.0.0
     # via -r requirements-test.in
-flask==2.2.3
+flask==2.3.2
     # via -r requirements-test.in
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via flask
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -26,7 +28,7 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-werkzeug==2.2.3
+werkzeug==2.3.6
     # via flask
-zipp==3.15.0
+zipp==3.16.0
     # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for directory in directories:
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="2.6.0",
+    version="2.7.0",
     author="Matt Shaw",
     author_email="matthew.shaw@landregistry.gov.uk",
     description="GOV.UK Frontend Jinja Macros",

--- a/tests/utils/test-entrypoint.sh
+++ b/tests/utils/test-entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 flake8 .
 (cd tests/utils && nohup python -m flask run --port 3000 &)
 wait-for-it localhost:3000
-./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v4.6.0
+./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v4.7.0


### PR DESCRIPTION
### Added

- [GOV.UK Frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) support
- [Exit this page component](https://design-system.service.gov.uk/components/exit-this-page/)