### PR TITLE
GOV.UK Frontend v5.6.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,5 +46,5 @@ jobs:
       run: |
         (cd tests/utils && nohup python -m flask run --port 3000 &)
         wait-for-it localhost:3000
-        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.5.0 --exclude page-template --ci
+        ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.6.0 --exclude page-template --ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [GOV.UK Frontend v5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) support
+- [Service navigation component](https://design-system.service.gov.uk/components/service-navigation/)
 
 ## [3.2.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.2.0) - 27/08/2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/3.2.0...main)
+## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/3.3.0...main)
+
+## [3.3.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.3.0) - xx/xx/2024
+
+### Added
+
+- [GOV.UK Frontend v5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) support
 
 ## [3.2.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.2.0) - 27/08/2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/3.3.0...main)
 
-## [3.3.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.3.0) - xx/xx/2024
+## [3.3.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.3.0) - 29/08/2024
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GOV.UK Frontend Jinja Macros
 
 [![PyPI version](https://badge.fury.io/py/govuk-frontend-jinja.svg)](https://pypi.org/project/govuk-frontend-jinja/)
-![govuk-frontend 5.5.0](https://img.shields.io/badge/govuk--frontend%20version-5.5.0-005EA5?logo=gov.uk&style=flat)
+![govuk-frontend 5.6.0](https://img.shields.io/badge/govuk--frontend%20version-5.6.0-005EA5?logo=gov.uk&style=flat)
 [![Python package](https://github.com/LandRegistry/govuk-frontend-jinja/actions/workflows/python-package.yml/badge.svg)](https://github.com/LandRegistry/govuk-frontend-jinja/actions/workflows/python-package.yml)
 
 **GOV.UK Frontend Jinja is a [community tool](https://design-system.service.gov.uk/community/resources-and-tools/) of the [GOV.UK Design System](https://design-system.service.gov.uk/). The Design System team is not responsible for it and cannot support you with using it. Contact the [maintainers](#contributors) directly if you need [help](#support) or you want to request a feature.**
@@ -16,6 +16,7 @@ The following table shows the version of GOV.UK Frontend Jinja that you should u
 
 | GOV.UK Frontend Jinja Version | Target GOV.UK Frontend Version |
 | ----------------------------- | ------------------------------ |
+| [3.3.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.3.0) | [5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) |
 | [3.2.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.2.0) | [5.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.5.0) |
 | [3.1.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.1.0) | [5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) |
 | [3.0.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.0.0) | [5.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.1.0) |

--- a/govuk_frontend_jinja/templates/components/service-navigation/macro.html
+++ b/govuk_frontend_jinja/templates/components/service-navigation/macro.html
@@ -1,0 +1,104 @@
+{% macro govukServiceNavigation(params) %}
+{% from "govuk_frontend_jinja/macros/attributes.html" import govukAttributes %}
+
+{%- set menuButtonText = params.menuButtonText | default("Menu", true) -%}
+{%- set navigationId = params.navigationId | default("navigation", true) %}
+
+{%- set commonAttributes %}
+class="govuk-service-navigation {%- if params.classes %} {{ params.classes }}{% endif %}"
+data-module="govuk-service-navigation"
+{{- govukAttributes(params.attributes) }}
+{% endset -%}
+
+{%- set innerContent %}
+  <div class="govuk-width-container">
+
+    {# Slot: start #}
+    {%- if params.slots and params.slots.start %}{{ params.slots.start | safe }}{% endif -%}
+
+    <div class="govuk-service-navigation__container">
+      {# Service name #}
+      {% if params.serviceName %}
+        <span class="govuk-service-navigation__service-name">
+          {% if params.serviceUrl %}
+            <a href="{{ params.serviceUrl }}" class="govuk-service-navigation__link">
+              {{ params.serviceName }}
+            </a>
+          {% else %}
+            <span class="govuk-service-navigation__text">
+              {{- params.serviceName -}}
+            </span>
+          {% endif %}
+        </span>
+      {% endif %}
+
+      {# Navigation #}
+      {% if params.navigation | length or params.slots and (params.slots.navigationStart or params.slots.navigationEnd) %}
+        <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-service-navigation__wrapper {%- if params.navigationClasses %} {{ params.navigationClasses }}{% endif %}">
+          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="{{ navigationId }}" {%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>
+            {{ menuButtonText }}
+          </button>
+
+          <ul class="govuk-service-navigation__list" id="{{ navigationId }}" >
+
+            {# Slot: navigationStart #}
+            {%- if params.slots and params.slots.navigationStart %}{{ params.slots.navigationStart | safe }}{% endif -%}
+
+            {% for item in params.navigation %}
+              {% set linkInnerContent %}
+                {# We wrap active links in strong tags so that users who
+                  override colours or styles will still have some indicator of
+                  the current nav item. #}
+                {% if item.active or item.current %}
+                  <strong class="govuk-service-navigation__active-fallback">{{- item.html | safe if item.html else item.text -}}</strong>
+                {% else %}
+                  {{- item.html | safe if item.html else item.text -}}
+                {% endif %}
+              {% endset %}
+
+              {#
+                If item.current, add active style and set aria-current="page"
+                Elseif item.active, add active style and set aria-current="true"
+              #}
+              <li class="govuk-service-navigation__item {%- if item.active or item.current %} govuk-service-navigation__item--active{% endif %}">
+                {% if item.href %}
+                  <a class="govuk-service-navigation__link" href="{{ item.href }}"
+                    {%- if item.active or item.current %} aria-current="{{ 'page' if item.current else 'true' }}"{% endif %}
+                    {{- govukAttributes(item.attributes) -}}>
+                    {{ linkInnerContent | safe }}
+                  </a>
+                {% elif item.html or item.text %}
+                  <span class="govuk-service-navigation__text"
+                    {%- if item.active or item.current %} aria-current="{{ 'page' if item.current else 'true' }}"{% endif %}>
+                    {{ linkInnerContent | safe }}
+                  </span>
+                {% endif %}
+              </li>
+            {% endfor %}
+
+            {# Slot: navigationEnd #}
+            {%- if params.slots and params.slots.navigationEnd %}{{ params.slots.navigationEnd | safe }}{% endif -%}
+          </ul>
+        </nav>
+      {% endif %}
+    </div>
+
+    {# Slot: end #}
+    {%- if params.slots and params.slots.end %}{{ params.slots.end | safe }}{% endif -%}
+
+  </div>
+{% endset -%}
+
+{# If a service name is included, we use a <section> element with an
+  aria-label to create a containing landmark region. Otherwise, the <nav> in
+  the innerContent can do the job just fine by itself. #}
+{% if params.serviceName or params.slots and (params.slots.start or params.slots.end) %}
+  <section aria-label="{{ params.ariaLabel | default("Service information") }}" {{ commonAttributes | safe }}>
+    {{ innerContent | safe }}
+  </section>
+{% else %}
+  <div {{ commonAttributes | safe }}>
+    {{ innerContent | safe }}
+  </div>
+{% endif %}
+{% endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for directory in directories:
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="3.2.0",
+    version="3.3.0",
     author="Matt Shaw",
     author_email="matthew.shaw@landregistry.gov.uk",
     description="GOV.UK Frontend Jinja Macros",

--- a/tests/utils/test-entrypoint.sh
+++ b/tests/utils/test-entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 flake8 .
 (cd tests/utils && nohup python -m flask run --port 3000 &)
 wait-for-it localhost:3000
-./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.5.0 --exclude page-template --ci
+./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.6.0 --exclude page-template --ci


### PR DESCRIPTION
### Added

- [GOV.UK Frontend v5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) support
- [Service navigation component](https://design-system.service.gov.uk/components/service-navigation/)