### PR TITLE
Set textarea value only when set.

### DIFF
--- a/govuk_frontend_jinja/templates/components/textarea/macro.html
+++ b/govuk_frontend_jinja/templates/components/textarea/macro.html
@@ -48,7 +48,7 @@
   {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete }}"{% endif %}
-  {{- govukAttributes(params.attributes) }}>{{ params.value }}</textarea>
+  {{- govukAttributes(params.attributes) }}>{%- if params.value %}{{ params.value }}{% endif %}</textarea>
 {% if params.formGroup and params.formGroup.afterInput %}
   {{ params.formGroup.afterInput.html | safe | trim | indent(2) if params.formGroup and params.formGroup.afterInput.html else params.formGroup.afterInput.text }}
 {% endif %}


### PR DESCRIPTION
Example below showing problem with govukTextarea rendering None when default is None 

```jinja2
  <h3>Example govukInput with default value of None</h3>
  {{ govukInput({
      "label": {
        "text": "What is the name of the event?",
        "classes": "govuk-label--l",
        "isPageHeading": true
      },
      "id": "event-name",
      "name": "eventName",
      "value": None
    }) }}

  <h3>Example govukTextarea with default value of None</h3>
  {{ govukTextarea({
    "name": "moreDetail",
    "id": "more-detail",
    "label": {
      "text": "Can you provide more detail?",
      "classes": "govuk-label--l",
      "isPageHeading": true
    },
    "hint": {
      "text": "Do not include personal or financial information, like your National Insurance number or credit card details"
    },
    "value": None
  }) }}
```
![image](https://github.com/user-attachments/assets/83c51a3e-ecae-42dc-ba54-c97ab8c8986e)
