### PR TITLE
FIX character count macro options typo

### DIFF
--- a/govuk_frontend_jinja/templates/components/character-count/macro.html
+++ b/govuk_frontend_jinja/templates/components/character-count/macro.html
@@ -104,7 +104,7 @@
   'formGroup': {
     'classes': 'govuk-character-count' ~ (' ' ~ params.formGroup.classes if params.formGroup and params.formGroup.classes),
     'attributes': attributesHtml,
-    'beforeInput': params.formGroup.beforeInput if params.fromGroup,
+    'beforeInput': params.formGroup.beforeInput if params.formGroup,
     'afterInput': {
       'html': countMessageHtml
     }


### PR DESCRIPTION
This tweaks one of the parameters being checked when creating the character count `textArea` macro which we've run across not being applied correctly.

To sense check the spec for expected values is
https://design-system.service.gov.uk/components/character-count/