### PR TITLE
Release v3.6.2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           (cd tests/utils && nohup python -m flask run --port 3000 &)
           wait-for-it localhost:3000
-          ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.10.0 --exclude page-template --ci
+          ./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.10.2 --exclude page-template --ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/3.6.0...main)
+## [Unreleased](https://github.com/LandRegistry/govuk-frontend-jinja/compare/3.6.2...main)
+
+### Added
+- Added support for [GOV.UK Frontend v5.10.2](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2).
+
+## [3.6.2](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.6.2) - 03/06/2025
 
 ## [3.6.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.6.0) - 14/05/2025
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following table shows the version of GOV.UK Frontend Jinja that you should u
 
 | GOV.UK Frontend Jinja Version                                                    | Target GOV.UK Frontend Version                                            |
 | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [3.6.2](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.6.2) | [5.10.2](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2)   |
 | [3.6.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.6.0) | [5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0)   |
 | [3.5.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.5.0) | [5.9.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0)   |
 | [3.4.1](https://github.com/LandRegistry/govuk-frontend-jinja/releases/tag/3.4.1) | [5.8.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.8.0)   |

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for directory in directories:
 
 setuptools.setup(
     name="govuk-frontend-jinja",
-    version="3.6.0",
+    version="3.6.2",
     author="Matt Shaw",
     author_email="matthew.shaw@landregistry.gov.uk",
     description="GOV.UK Frontend Jinja Macros",

--- a/tests/utils/test-entrypoint.sh
+++ b/tests/utils/test-entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 flake8 .
 (cd tests/utils && nohup python -m flask run --port 3000 &)
 wait-for-it localhost:3000
-./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.10.0 --exclude page-template --ci
+./govuk-frontend-diff http://localhost:3000 --govuk-frontend-version=v5.10.2 --exclude page-template --ci


### PR DESCRIPTION
- Adds support for [govuk-frontend v5.10.2](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.2)

- Brings in fixes from v5.10.1 - https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.1