### PR TITLE
Replicate SECURITY.md and license information from common-dev-env

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 HM Land Registry
+Copyright (C) 2020 Crown Copyright (HM Land Registry)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# HM Land Registry Security and Vulnerability Reporting Policy
+
+This repository follows HM Land Registry's [reporting policy][policy] for reporting vulnerabilities that affect HM Land Registry services and systems. All persons disclosing vulnerabilities that affect this repository are requested to follow this policy when reporting.
+
+Do not raise public issues or pull requests for any vulnerabilities affecting HM Land Registry services and systems.
+
+[policy]: https://www.gov.uk/guidance/report-a-vulnerability-on-an-hm-land-registry-service-or-system


### PR DESCRIPTION
Replicated SECURITY.md from the [common dev-env repo](https://github.com/LandRegistry/common-dev-env/blob/master/SECURITY.md) to signpost HMLR reporting policy. Additionally, amended license information to reflect this code base is under Crown Copyright.